### PR TITLE
Feature: `target` supports internet addresses for markdown reading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,12 +20,11 @@ log = "0.4"
 minimad = "0.8"
 reqwest = { version = "0.11.9", optional = true, features = ["blocking"]}
 simplelog = "0.10"
-tempfile = { version = "3.3.0", optional = true }
 termimad = "0.14.2"
 terminal-light = "0.5"
 
 [features]
-web = ["reqwest", "tempfile"]
+web = ["reqwest"]
 
 [patch.crates-io]
 # minimad = { path = "../minimad" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,15 +11,21 @@ categories = ["command-line-utilities"]
 readme = "README.md"
 
 [dependencies]
+cfg-if = "1.0.0"
 clap = "2.33"
 crossterm = "0.21"
 custom_error = "1.9"
 lazy_static = "1.4"
 log = "0.4"
 minimad = "0.8"
+reqwest = { version = "0.11.9", optional = true, features = ["blocking"]}
 simplelog = "0.10"
+tempfile = { version = "3.3.0", optional = true }
 termimad = "0.14.2"
 terminal-light = "0.5"
+
+[features]
+web = ["reqwest", "tempfile"]
 
 [patch.crates-io]
 # minimad = { path = "../minimad" }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -31,7 +31,7 @@ pub fn read_launch_args() -> Result<AppLaunchArgs, ProgramError> {
         Some(path) => {
             cfg_if::cfg_if! {
                 if #[cfg(feature = "web")] {
-                    if path.starts_with("https") {
+                    if path.starts_with("https://") && !PathBuf::from(path).exists() {
                         link_to_tempbuf(path)?
                     } else {
                         PathBuf::from(path)

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,0 +1,7 @@
+use cfg_if;
+
+cfg_if::cfg_if! {
+    if #[cfg(feature = "web")] {
+        pub static CLIMA_WEB: &str = "0clima.md";
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,11 @@ extern crate log;
 mod cli;
 mod errors;
 mod viewer;
+mod constants;
 
 use {
     crate::errors::ProgramError,
+    cfg_if,
     log::LevelFilter,
     std::{
         env,
@@ -14,6 +16,7 @@ use {
         str::FromStr,
     },
 };
+
 
 
 /// configure the application log according to env variable.
@@ -48,6 +51,11 @@ fn configure_log() {
 fn run() -> Result<(), ProgramError> {
     configure_log();
     viewer::run(cli::read_launch_args()?)?;
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "web")] {
+            let _unlink = ::std::fs::remove_file(constants::CLIMA_WEB)?;
+        }
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Adds support for passing a URL to clima and downloading it locally to view. 


### Installation
```sh
# cargo install --features web clima
cargo install --features web --path .
```