### PR TITLE
Update termimad version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ custom_error = "1.9"
 lazy-regex = "2.2.2"
 lazy_static = "1.4"
 reqwest = { version = "0.11.9", default-features=false, features = ["blocking", "rustls-tls"]}
-termimad = "0.20.2"
+termimad = "0.22.0"
 terminal-light = "1.0.0"
 
 [profile.release]


### PR DESCRIPTION
Otherwise I got the following build error:
```
error[E0277]: the trait bound `crossterm::style::Color: From<coolor::Color>` is not satisfied
  --> /home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/termimad-0.20.4/src/compound_style.rs:68:19
   |
68 |             *fg = coolor::Color::blend(src, 1.0 - weight, dest, weight).into();
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ---- required by a bound introduced by this call
   |                   |
   |                   the trait `From<coolor::Color>` is not implemented for `crossterm::style::Color`
   |
   = help: the trait `From<(u8, u8, u8)>` is implemented for `crossterm::style::Color`
   = note: required for `coolor::Color` to implement `Into<crossterm::style::Color>`
```